### PR TITLE
Fix message when no changes detected

### DIFF
--- a/Command/DiffFileCommand.php
+++ b/Command/DiffFileCommand.php
@@ -57,7 +57,7 @@ class DiffFileCommand extends \Doctrine\DBAL\Migrations\Tools\Console\Command\Di
         $down = $this->buildCodeFromSql($configuration, $fromSchema->getMigrateFromSql($toSchema, $platform));
 
         if (!$up && !$down) {
-            $output->writeln('No changes detected in your mapping information.', 'ERROR');
+            $output->writeln('No changes detected in your mapping information.');
 
             return;
         }


### PR DESCRIPTION
`'ERROR`' is not a valid value for writeln and with recent version of Symfony (or PHP, I don't know) an error is now triggered (`A non-numeric value encoutered`) instead of displaying the message.

Doctrine [has fixed the issue by removing the parameter](https://github.com/doctrine/migrations/blob/master/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php#L104) so let's do the same!