### PR TITLE
IMPORTANT FIX: Adding the missing dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": ">=7.1",
         "symfony/framework-bundle": "~4.0",
         "doctrine/doctrine-bundle": "~1.0",
-        "doctrine/migrations": "~1.6"
+        "doctrine/migrations": "~1.6",
+        "doctrine/doctrine-migrations-bundle": "~1.3"
     }
 }


### PR DESCRIPTION
Before that, if a project hasn't the doctrine/doctrine-migration-bundle, the command was unable to run properly as of a crash