### PR TITLE
allow Symfony 3.4 to use the project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "a5sys/doctrine-migration-tools-bundle",
+    "description": "Ease use of doctrine migrations",
     "type": "symfony-bundle",
     "autoload": {
         "psr-4": { "A5sys\\DoctrineMigrationToolsBundle\\": "" }
@@ -7,7 +8,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1",
-        "symfony/framework-bundle": "~4.0",
+        "symfony/framework-bundle": "~3.4|~4.0",
         "doctrine/doctrine-bundle": "~1.0",
         "doctrine/migrations": "~1.6",
         "doctrine/doctrine-migrations-bundle": "~1.3"


### PR DESCRIPTION
Symfony 3.4, with the 4.0 file architecture, is also able to use the bundle.
The composer.json only mentionned Symfony projects >4.0,I added the 3.4 ability