### PR TITLE
Creates an EmptySchemaProvider dependency for DiffGenerator

### DIFF
--- a/Command/DiffFileCommand.php
+++ b/Command/DiffFileCommand.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Migrations\Generator\DiffGenerator;
 use Doctrine\Migrations\Generator\Exception\NoChangesDetected;
+use Doctrine\Migrations\Provider\EmptySchemaProvider;
 use Doctrine\Migrations\Provider\SchemaProviderInterface;
 use Doctrine\Migrations\Tools\Console\Helper\MigrationDirectoryHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -82,7 +83,8 @@ class DiffFileCommand extends \Doctrine\Migrations\Tools\Console\Command\DiffCom
             $this->getSchemaProvider(),
             $this->connection->getDatabasePlatform(),
             $this->dependencyFactory->getMigrationGenerator(),
-            $this->dependencyFactory->getMigrationSqlGenerator()
+            $this->dependencyFactory->getMigrationSqlGenerator(),
+            new EmptySchemaProvider($this->schemaManager)
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "require": {
         "php": ">=7.1",
         "symfony/framework-bundle": "~3.4|~4.0|~5.0",
-        "doctrine/doctrine-migrations-bundle": "^2.2"
+        "doctrine/doctrine-migrations-bundle": "^2.0",
+        "doctrine/migrations": "^2.3"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
     "require": {
         "php": ">=7.1",
         "symfony/framework-bundle": "~3.4|~4.0|~5.0",
-        "doctrine/doctrine-migrations-bundle": "~2.0"
+        "doctrine/doctrine-migrations-bundle": "^2.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
     "require": {
         "php": ">=7.1",
         "symfony/framework-bundle": "~3.4|~4.0|~5.0",
-        "doctrine/doctrine-migrations-bundle": "^2.0"
+        "doctrine/doctrine-migrations-bundle": "^2.2"
     }
 }


### PR DESCRIPTION
**Fix**
```log
[console] Error thrown while running command "doctrine:migrations:diff-file --check". Message: "Too few arguments to function Doctrine\Migrations\Generator\DiffGenerator::__construct(), 6 passed in /srv/php/vendor/a5sys/doctrine-migration-tools-bundle/Command/DiffFileCommand.php on line 85 and exactly 7 expected" ["exception" => ArgumentCountError { …},"command" => "doctrine:migrations:diff-file --check","message" => "Too few arguments to function Doctrine\Migrations\Generator\DiffGenerator::__construct(), 6 passed in /srv/php/vendor/a5sys/doctrine-migration-tools-bundle/Command/DiffFileCommand.php on line 85 and exactly 7 expected"]
In DiffGenerator.php line 47:
                                                                               
  Too few arguments to function Doctrine\Migrations\Generator\DiffGenerator::  
  __construct(), 6 passed in /srv/php/vendor/a5sys/doctrine-migration-tools-b  
  undle/Command/DiffFileCommand.php on line 85 and exactly 7 expected     
```